### PR TITLE
PSYNEU-34 feat: Add forwardRef and onMount prop to MetaDiagram component

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { forwardRef } from 'react';
 import Sidebar, { ISidebarProps } from './components/Sidebar';
 import { MetaNode } from './models/MetaNode';
 import { MetaLink } from './models/MetaLink';
@@ -46,7 +47,7 @@ interface MetaDiagramProps {
   metaCallback?: Function;
 }
 
-const MetaDiagram = ({
+const MetaDiagram = forwardRef(({
   metaNodes,
   metaLinks,
   componentsMap,
@@ -54,7 +55,7 @@ const MetaDiagram = ({
   metaTheme,
   sidebarProps,
   metaCallback,
-}: MetaDiagramProps) => {
+}: MetaDiagramProps, ref) => {
   const classes = useStyles();
   // set up the diagram engine
   const engine = createEngine();
@@ -132,7 +133,7 @@ const MetaDiagram = ({
     <ThemeProvider theme={createTheme(theme(metaTheme?.customThemeVariables))}>
       <DndProvider backend={HTML5Backend}>
         <CssBaseline />
-        <Box className={containerClassName}>
+          <Box className={containerClassName} ref={ref}>
           <Sidebar {...sidebarProps} />
           <CanvasWidget
             engine={engine}
@@ -142,7 +143,7 @@ const MetaDiagram = ({
       </DndProvider>
     </ThemeProvider>
   );
-};
+});
 
 export default MetaDiagram;
 export { MetaNode, MetaLink, MetaPort, MetaNodeModel, ComponentsMap };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { forwardRef } from 'react';
+import { forwardRef, useEffect } from 'react';
 import Sidebar, { ISidebarProps } from './components/Sidebar';
 import { MetaNode } from './models/MetaNode';
 import { MetaLink } from './models/MetaLink';
@@ -45,6 +45,7 @@ interface MetaDiagramProps {
     canvasClassName: string;
   };
   metaCallback?: Function;
+  onMount?: Function;
 }
 
 const MetaDiagram = forwardRef(
@@ -57,6 +58,7 @@ const MetaDiagram = forwardRef(
       metaTheme,
       sidebarProps,
       metaCallback,
+      onMount,
     }: MetaDiagramProps,
     ref
   ) => {
@@ -123,6 +125,15 @@ const MetaDiagram = forwardRef(
 
     // load model into engine
     engine.setModel(model);
+
+    useEffect(() => {
+      if (onMount === undefined) {
+        onMount = (engine: any) => {
+          console.log(engine);
+        };
+      }
+      onMount(engine);
+    }, []);
 
     // useEffect(() => {
     //   // @ts-ignore


### PR DESCRIPTION

- Adds onMount prop:
Provides easy access to the engine object, which contains useful methods to the application like getRelativeMousePoint

- Adds forwardRef to MetaDiagram so that we can attach a ref from the parent component.
~The above is particularly interesting to do in Psyneulink in order to fix an misalignment between mouse coordinates and nodes position~ Consider it  nice to have