### PR TITLE
Feature/psyneu-107

### DIFF
--- a/src/components/sidebar/Sidebar.tsx
+++ b/src/components/sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useState } from 'react';
+import React, { Fragment } from 'react';
 import { Box, List } from '@mui/material';
 
 import SidebarItem from './SidebarItem';
@@ -10,9 +10,14 @@ import { PanningState } from './states/PanningState';
 import { CreateLinkState } from './states/CreateLinkState';
 import { SelectionState } from './states/SelectionState';
 
-const Sidebar = ({ engine, sidebarNodes, updateSelection }: ISidebarProps) => {
-  const [currentState, setCurrentState] = useState<string | null>(
-    () => DefaultSidebarNodeTypes.CREATE_LINK
+const Sidebar = ({
+  selected,
+  sidebarNodes,
+  updateSelection,
+  engine,
+}: ISidebarProps) => {
+  const [currentState, setCurrentState] = React.useState<string | null>(
+    () => selected ?? DefaultSidebarNodeTypes.CREATE_LINK
   );
 
   const reactDiagramsState = engine
@@ -37,8 +42,8 @@ const Sidebar = ({ engine, sidebarNodes, updateSelection }: ISidebarProps) => {
     updateSelection(selectedID);
   };
 
-  useEffect(() => {
-    handleSelection(DefaultSidebarNodeTypes.PANNING);
+  React.useEffect(() => {
+    handleSelection(currentState as DefaultSidebarNodeTypes);
   }, []);
 
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,7 +20,7 @@ import { DefaultSidebarNodeTypes, EventTypes } from './constants';
 import { CanvasWidget } from './components/CanvasWidget';
 import { MetaLinkModel } from './react-diagrams/MetaLinkModel';
 import { DefaultState } from './react-diagrams/state/DefaultState';
-import { ISidebarProps } from './types/sidebar';
+import { ISidebarNodeProps } from './types/sidebar';
 import Sidebar from './components/sidebar/Sidebar';
 import { InputType } from '@projectstorm/react-canvas-core';
 
@@ -40,7 +40,9 @@ interface MetaDiagramProps {
   metaNodes: MetaNodeModel[];
   metaLinks: MetaLinkModel[];
   componentsMap: ComponentsMap;
-  sidebarProps?: ISidebarProps;
+  sidebarNodes?: ISidebarNodeProps[];
+  selectedSidebarNodeId?: string;
+  updateSidebarSelection?: (id: string) => void;
   wrapperClassName?: string;
   canvasClassName?: string;
   metaTheme: {
@@ -60,7 +62,9 @@ const MetaDiagram = forwardRef(
       componentsMap,
       wrapperClassName,
       metaTheme,
-      sidebarProps,
+      sidebarNodes,
+      selectedSidebarNodeId,
+      updateSidebarSelection,
       metaCallback,
       onMount,
       globalProps,
@@ -192,6 +196,7 @@ const MetaDiagram = forwardRef(
     // update state selection state
     const updateSelection = (id: string) => {
       const isSelect = id === DefaultSidebarNodeTypes.SELECT;
+      if (!!updateSidebarSelection) updateSidebarSelection(id);
 
       if (isSelect && Boolean(state.isSelection)) {
         return;
@@ -270,8 +275,9 @@ const MetaDiagram = forwardRef(
           <CssBaseline />
           <Box className={containerClassName} ref={ref}>
             <Sidebar
-              {...sidebarProps}
               engine={engine}
+              selected={selectedSidebarNodeId}
+              sidebarNodes={sidebarNodes}
               updateSelection={updateSelection}
             />{' '}
             <CanvasWidget

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -73,7 +73,7 @@ const applicationTheme = (params: ThemeVars) => {
 
           .sub-sidebar {
             z-index: 4;
-            width: 2.5rem;
+            width: 2.75rem;
             background: ${subBarBg};
             position: fixed;
             border-radius: 0 0.5rem 0.5rem 0;
@@ -114,13 +114,34 @@ const applicationTheme = (params: ThemeVars) => {
           }
 
           .sub-sidebar .MuiList-root {
-            padding: 0.25rem;
+            padding: 0.375rem;
           }
 
           .sub-sidebar .wrapper {
             max-height: 16rem;
             overflow-y: scroll;
             overflow-x: hidden
+          }
+
+          .sub-sidebar .wrapper::-webkit-scrollbar {
+            background-color: none;
+            width: 0.375rem;
+          }
+        
+          /* background of the scrollbar except button or resizer */
+          .sub-sidebar .wrapper::-webkit-scrollbar-track {
+              background-color: none;
+          }
+          
+          /* scrollbar itself */
+          .sub-sidebar .wrapper::-webkit-scrollbar-thumb {
+              background-color: ${chipTextColor};
+              border-radius: 0.375rem;
+          }
+          
+          /* set button(top and bottom of the scrollbar) */
+          .sub-sidebar .wrapper::-webkit-scrollbar-button {
+              display:none;
           }
 
           .canvas-widget {

--- a/src/types/sidebar.d.ts
+++ b/src/types/sidebar.d.ts
@@ -45,7 +45,7 @@ export interface ISubSidebarItemProps extends IHandleSelection {
 }
 
 export interface ISidebarProps {
-  selectedBarNode?: string;
+  selected?: string;
   sidebarNodes?: ISidebarNodeProps[];
   updateSelection: (id: string) => void;
   engine: CanvasEngine;


### PR DESCRIPTION
Keep subsidebar opened after drag
 
meta-diagram sidebar props object has been refactored to individual props in metadiagram because the app needs to be aware of a few of the sidebar props in real time e.g selectedSiderbarNodeId 